### PR TITLE
Update .NET version to 8.0 for all projects

### DIFF
--- a/Pds/Pds.Api.Contracts/Pds.Api.Contracts.csproj
+++ b/Pds/Pds.Api.Contracts/Pds.Api.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Pds/Pds.Api.Tests/Pds.Api.Tests.csproj
+++ b/Pds/Pds.Api.Tests/Pds.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 

--- a/Pds/Pds.Core/Pds.Core.csproj
+++ b/Pds/Pds.Core/Pds.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Pds/Pds.Data/Pds.Data.csproj
+++ b/Pds/Pds.Data/Pds.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Pds/Pds.Di/Pds.Di.csproj
+++ b/Pds/Pds.Di/Pds.Di.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Pds/Pds.Mappers/Pds.Mappers.csproj
+++ b/Pds/Pds.Mappers/Pds.Mappers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Pds/Pds.Services/Pds.Services.csproj
+++ b/Pds/Pds.Services/Pds.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Pds/Pds.Web.Models/Pds.Web.Models.csproj
+++ b/Pds/Pds.Web.Models/Pds.Web.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
Related to #247

Updates the .NET framework version to 8.0 across multiple projects within the repository.

- **Updates Target Framework**: Changes the `<TargetFramework>` element from `net7.0` to `net8.0` in the `.csproj` files for `Pds.Api.Contracts`, `Pds.Api.Tests`, `Pds.Core`, `Pds.Data`, `Pds.Di`, `Pds.Mappers`, `Pds.Services`, and `Pds.Web.Models`. This aligns all specified projects with the .NET 8.0 framework, as per the issue's requirement.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/it-beard/bloggers-cms/issues/247?shareId=b5267adb-7dd1-4198-8be7-ba3b24899719).